### PR TITLE
Create generic constructor for the S4 method "describe" WPSworldgrids.R

### DIFF
--- a/R/WPSworldgrids.R
+++ b/R/WPSworldgrids.R
@@ -28,6 +28,7 @@ setMethod("getProcess", signature(x = "WPS"), function(x){
 })
 
 ## get arguments:
+setGeneric("describe", function(x, ...){standardGeneric("describe")})
 setMethod("describe", signature(x = "WPS"), function(x, request = "describeprocess", identifier){
   if(requireNamespace("XML", quietly = TRUE)){
     uri = paste(paste(x@server$URI, "?", sep=""), paste(x@server$service, x@server$version, paste("request=", request, sep=""), paste("identifier=", identifier, sep=""), sep="&"), sep="")


### PR DESCRIPTION
Fix for package to install:

This error is occurring because the generic constructor for the S4 method "describe" isn't being created. I have no idea why; the code contains the file AAAA.R (which is sourced first in the package) with a perfectly sensible constructor in it:

if(!isGeneric("describe")){
setGeneric("describe", function(x, ...){standardGeneric("describe")}) }
For whatever reason, this test is failing -- i.e. "describe" is a generic -- and so the way to get it to install cleanly is -- and insert giant "I have no idea if this is actually a good idea" warning here --

Download the archive from CRAN
Untar / gz
Above line 31 of R/wpsworldgrids.R, which defines the method, add the line for the constructor: setGeneric("describe", function(x, ...){standardGeneric("describe")}) Run devtools::install('/path/to/your/folder/GSIF') to install it Pray that this hasn't cocked anything clever up I do not understand... Note that the methods in GDAL this is based on are themselves due to become "end of life" soon:

Source: https://stackoverflow.com/questions/73559636/unable-to-install-gsif-package-in-r